### PR TITLE
fix:demo prometheus middleware

### DIFF
--- a/demo/fastapi_langchain/main.py
+++ b/demo/fastapi_langchain/main.py
@@ -13,7 +13,7 @@ app = FastAPI(
     version="0.0.1"
 )
 app.add_middleware(GZipMiddleware, minimum_size=1000)
-app.add_middleware(PrometheusMiddleware, app_name=service_name, group_paths=True)
+app.add_middleware(PrometheusMiddleware, app_name=service_name, group_paths=True, filter_unhandled_paths=True)
 app.add_route("/metrics", handle_metrics)  # Metrics are published at this endpoint
 
 # Initialise xpuls.ai


### PR DESCRIPTION
## What does this PR address?
When I run the demo case, a warning log is generated:
`lib/python3.11/site-packages/starlette_exporter/middleware.py:97: FutureWarning: group_paths and filter_unhandled_paths will change defaults from False to True in the next release. See https://github.com/stephenhillier/starlette_exporter/issues/79 for more info
  warnings.warn(`
  
  According to [this issue](https://github.com/stephenhillier/starlette_exporter/issues/79), I should add `filter_unhandled_paths=True`


https://github.com/stephenhillier/starlette_exporter/issues/79
